### PR TITLE
Add create goal functionality to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Install it yourself as:
     $ idt team set
     $ idt entry new "Just setup the IDoneThis CLI"
     $ idt entry list
+    $ idt entry goal "Use the IDoneThis CLI once more today"
 
 ## Development
 

--- a/lib/idonethis_cli/client/entry.rb
+++ b/lib/idonethis_cli/client/entry.rb
@@ -16,6 +16,17 @@ module IdonethisCli
         false
       end
 
+      def create_goal(team_id, body)
+        response = token.post(API_PATH + '/entries', 
+                              params: { body: body,
+                                        team_id: team_id,
+                                        status: 'goal'})
+        JSON.parse(response.body)
+      rescue => e
+        @error = e.response
+        false
+      end
+
       def list(team_id)
         response = token.get(API_PATH + '/entries', { team_id: team_id })
         entries  = JSON.parse(response.body)

--- a/lib/idonethis_cli/entry.rb
+++ b/lib/idonethis_cli/entry.rb
@@ -10,6 +10,14 @@ module IdonethisCli
       post_entry body
     end
 
+    desc "goal BODY", "enter a single goal entry"
+    long_desc "create a goal entry for your set team"
+    def goal(body)
+      return nil unless authenticated?
+      return nil unless team_set?
+      post_entry(body, 'goal')
+    end
+
     desc "prompt", "enter multiple entries"
     long_desc "prompts for your entries"
     def prompt
@@ -46,8 +54,12 @@ module IdonethisCli
       @client ||= IdonethisCli::Client::Entry.new(token)
     end
 
-    def post_entry(body)
-      response = entry_client.create(settings.team['hash_id'], body)
+    def post_entry(body, type='done')
+      if type == 'goal'
+        response = entry_client.create_goal(settings.team['hash_id'], body)
+      else
+        response = entry_client.create(settings.team['hash_id'], body)
+      end
       if response
         cli.say "Entry created for #{response['user']['full_name']} on #{settings.team['name']}"
       else


### PR DESCRIPTION
This commit adds the minimum to complete a goal entry from the CLI. The
code works but can be refactored and built upon for instance it could
easily support having an entry for blocks feature.  With that case
a refactor would definitely be in order but I wanted something I could
use right away and I do find this tool very useful. Any feedback is
definitely appreciated.